### PR TITLE
Fix query parameter decoding on Cloud Run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2519,6 +2519,7 @@ dependencies = [
  "temp-env",
  "thiserror",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ async-trait = "0.1"
 thiserror = "1.0"
 regex = "1.8"
 base64 = "0.13"
+url = "2.2"
 
 # Lambda関連の依存関係
 lambda_runtime = { version = "0.13.0", optional = true }

--- a/src/cloudrun.rs
+++ b/src/cloudrun.rs
@@ -1,64 +1,42 @@
 //! Google Cloud Run向けの実装
 
-use std::collections::HashMap;
-use std::sync::Arc;
-use log::{debug, error, info};
-use actix_web::{web, App, HttpRequest, HttpResponse, HttpServer, dev::Service};
 use actix_web::http::header::HeaderMap;
 use actix_web::web::Bytes;
+use actix_web::{web, App, HttpRequest, HttpResponse, HttpServer};
+use log::{error, info};
+use std::collections::HashMap;
+use std::sync::Arc;
+use url::form_urlencoded;
 
 use crate::common::{Method, Request, Response};
-use crate::error::Error;
 use crate::RunBridge;
 
 /// actix-webのHeaderMapから共通形式のヘッダーに変換
 fn convert_headers(headers: &HeaderMap) -> HashMap<String, String> {
     let mut result = HashMap::new();
-    
+
     for (key, value) in headers.iter() {
         if let Ok(value_str) = value.to_str() {
             result.insert(key.as_str().to_string(), value_str.to_string());
         }
     }
-    
+
     result
 }
 
 /// actix-webのリクエストから共通形式のRequestに変換
-async fn convert_request(
-    req: &HttpRequest,
-    path: String,
-    body: Option<Bytes>,
-) -> Request {
+async fn convert_request(req: &HttpRequest, path: String, body: Option<Bytes>) -> Request {
     // HTTPメソッドの取得
-    let method = match req.method().as_str() {
-        "GET" => Method::GET,
-        "POST" => Method::POST,
-        "PUT" => Method::PUT,
-        "DELETE" => Method::DELETE,
-        "PATCH" => Method::PATCH,
-        "HEAD" => Method::HEAD,
-        "OPTIONS" => Method::OPTIONS,
-        _ => Method::GET,
-    };
+    let method = Method::from_str(req.method().as_str()).unwrap_or(Method::GET);
 
     // ヘッダーの変換
     let headers = convert_headers(req.headers());
 
-    // クエリパラメータの取得
-    let query_params = req
-        .query_string()
-        .split('&')
-        .filter(|s| !s.is_empty())
-        .filter_map(|item| {
-            let parts: Vec<&str> = item.splitn(2, '=').collect();
-            if parts.len() == 2 {
-                Some((parts[0].to_string(), parts[1].to_string()))
-            } else {
-                None
-            }
-        })
-        .collect();
+    // クエリパラメータの取得 (URLデコード済み)
+    let query_params: HashMap<String, String> =
+        form_urlencoded::parse(req.query_string().as_bytes())
+            .into_owned()
+            .collect();
 
     // リクエストボディの処理
     let body = body.map(|b| b.to_vec());
@@ -81,7 +59,10 @@ fn convert_to_http_response(response: Response) -> HttpResponse {
         403 => HttpResponse::Forbidden(),
         404 => HttpResponse::NotFound(),
         500 => HttpResponse::InternalServerError(),
-        _ => HttpResponse::build(actix_web::http::StatusCode::from_u16(response.status).unwrap_or(actix_web::http::StatusCode::OK)),
+        _ => HttpResponse::build(
+            actix_web::http::StatusCode::from_u16(response.status)
+                .unwrap_or(actix_web::http::StatusCode::OK),
+        ),
     };
 
     // ヘッダーの設定
@@ -99,33 +80,27 @@ fn convert_to_http_response(response: Response) -> HttpResponse {
 
 /// RunBridgeアプリケーションをハンドリングするactix-web用ハンドラー
 async fn handle_request(
-    req: HttpRequest, 
+    req: HttpRequest,
     body: Option<Bytes>,
     app: web::Data<Arc<RunBridge>>,
 ) -> HttpResponse {
     let path = req.uri().path().to_string();
-    let method_str = req.method().as_str();
-    info!("Received request: {} {}", method_str, path);
 
     // リクエストの変換
     let request = convert_request(&req, path.clone(), body).await;
-    
-    // メソッドの変換
-    let method = match Method::from_str(method_str) {
-        Some(m) => m,
-        None => {
-            error!("Unsupported HTTP method: {}", method_str);
-            return HttpResponse::MethodNotAllowed().finish();
-        }
-    };
+    info!("Received request: {} {}", request.method, path);
+
+    // メソッドの取得
+    let method = request.method;
 
     // ハンドラーの検索
     let handler = match app.find_handler(&path, &method) {
         Some(handler) => handler,
         None => {
             error!("Route not found: {} {}", method, path);
-            return convert_to_http_response(Response::not_found()
-                .with_body("Not Found".as_bytes().to_vec()));
+            return convert_to_http_response(
+                Response::not_found().with_body("Not Found".as_bytes().to_vec()),
+            );
         }
     };
 
@@ -137,8 +112,9 @@ async fn handle_request(
             Err(e) => {
                 error!("Middleware error: {}", e);
                 let status = e.status_code();
-                return convert_to_http_response(Response::new(status)
-                    .with_body(format!("Error: {}", e).as_bytes().to_vec()));
+                return convert_to_http_response(
+                    Response::new(status).with_body(format!("Error: {}", e).as_bytes().to_vec()),
+                );
             }
         }
     }
@@ -174,33 +150,73 @@ async fn handle_request(
 /// アプリケーションをCloud Run/HTTPサーバーとして実行
 pub async fn run_cloud_run(app: RunBridge, host: &str, port: u16) -> std::io::Result<()> {
     info!("Starting HTTP server on {}:{}", host, port);
-    
+
     // アプリケーションをArcで包んでスレッド間で共有可能にする
     let app_data = Arc::new(app);
-    
+
     // HTTPサーバーの構築と起動
     HttpServer::new(move || {
         let app_data = web::Data::new(app_data.clone());
-        
+
         App::new()
             .app_data(app_data.clone())
             // すべてのリクエストをキャッチする汎用ハンドラー
-            .route("/{path:.*}", web::get().to(|req, app: web::Data<Arc<RunBridge>>| 
-                handle_request(req, None, app)))
-            .route("/{path:.*}", web::post().to(|req, body: Option<Bytes>, app: web::Data<Arc<RunBridge>>| 
-                handle_request(req, body, app)))
-            .route("/{path:.*}", web::put().to(|req, body: Option<Bytes>, app: web::Data<Arc<RunBridge>>| 
-                handle_request(req, body, app)))
-            .route("/{path:.*}", web::delete().to(|req, app: web::Data<Arc<RunBridge>>| 
-                handle_request(req, None, app)))
-            .route("/{path:.*}", web::patch().to(|req, body: Option<Bytes>, app: web::Data<Arc<RunBridge>>| 
-                handle_request(req, body, app)))
-            .route("/{path:.*}", web::head().to(|req, app: web::Data<Arc<RunBridge>>| 
-                handle_request(req, None, app)))
-            .route("/{path:.*}", web::method(actix_web::http::Method::OPTIONS).to(|req, app: web::Data<Arc<RunBridge>>| 
-                handle_request(req, None, app)))
+            .route(
+                "/{path:.*}",
+                web::get().to(|req, app: web::Data<Arc<RunBridge>>| handle_request(req, None, app)),
+            )
+            .route(
+                "/{path:.*}",
+                web::post().to(|req, body: Option<Bytes>, app: web::Data<Arc<RunBridge>>| {
+                    handle_request(req, body, app)
+                }),
+            )
+            .route(
+                "/{path:.*}",
+                web::put().to(|req, body: Option<Bytes>, app: web::Data<Arc<RunBridge>>| {
+                    handle_request(req, body, app)
+                }),
+            )
+            .route(
+                "/{path:.*}",
+                web::delete()
+                    .to(|req, app: web::Data<Arc<RunBridge>>| handle_request(req, None, app)),
+            )
+            .route(
+                "/{path:.*}",
+                web::patch().to(|req, body: Option<Bytes>, app: web::Data<Arc<RunBridge>>| {
+                    handle_request(req, body, app)
+                }),
+            )
+            .route(
+                "/{path:.*}",
+                web::head()
+                    .to(|req, app: web::Data<Arc<RunBridge>>| handle_request(req, None, app)),
+            )
+            .route(
+                "/{path:.*}",
+                web::method(actix_web::http::Method::OPTIONS)
+                    .to(|req, app: web::Data<Arc<RunBridge>>| handle_request(req, None, app)),
+            )
     })
     .bind((host, port))?
     .run()
     .await
-} 
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::test::TestRequest;
+
+    #[actix_web::test]
+    async fn query_params_are_url_decoded() {
+        let req = TestRequest::with_uri("/?name=John%20Doe&city=T%C5%8Dky%C5%8D").to_http_request();
+        let request = convert_request(&req, "/".to_string(), None).await;
+        assert_eq!(
+            request.query_params.get("name"),
+            Some(&"John Doe".to_string())
+        );
+        assert_eq!(request.query_params.get("city"), Some(&"Tōkyō".to_string()));
+    }
+}


### PR DESCRIPTION
## Summary
- decode Cloud Run query strings using `url::form_urlencoded`
- refactor Cloud Run handler to reuse parsed method instead of recomputing

## Testing
- `cargo test`
- `cargo test --features cloud_run`
- `cargo build --examples`
- `cargo build` in `example/helloworld`
- `cargo build` in `example/helloworld_async`
- `cargo build` in `example/middleware`


------
https://chatgpt.com/codex/tasks/task_e_68946bdfc3dc8320a7f85eb0ec750974